### PR TITLE
fix a bug when 'charIndex'=0

### DIFF
--- a/src/vertical.tsx
+++ b/src/vertical.tsx
@@ -19,7 +19,7 @@ const children = chars.map((char) => <div key={char}>{char}</div>);
 export function Vertical({ letter }: VerticalProps) {
   const charIndex = charsIndex.get(letter);
 
-  if (!charIndex) {
+  if (charIndex === undefined) {
     return <React.Fragment>{letter}</React.Fragment>;
   }
 


### PR DESCRIPTION
Fixed a bug in the conficional !charIndex. Instead it should be compared to 'undefined' because zero is falsy in JavaScript.
This change improves the animation when the number nine appears.